### PR TITLE
Simplify expand

### DIFF
--- a/lib/surface/components/markdown.ex
+++ b/lib/surface/components/markdown.ex
@@ -45,35 +45,19 @@ defmodule Surface.Components.Markdown do
       # Need to reconstruct the relative line
       |> markdown_as_html!(meta.caller, meta.line, opts)
 
-    node = %Surface.AST.Literal{value: html}
+    code =
+      cond do
+        unwrap ->
+          html
 
-    cond do
-      unwrap ->
-        node
+        class ->
+          ~s(<div class="#{class}">#{html}</div>)
 
-      class ->
-        %Surface.AST.Tag{
-          element: "div",
-          directives: [],
-          attributes: [
-            %Surface.AST.Attribute{
-              name: "class",
-              value: %Surface.AST.Literal{value: class}
-            }
-          ],
-          children: [node],
-          meta: meta
-        }
+        true ->
+          ~s(<div>#{html}</div>)
+      end
 
-      true ->
-        %Surface.AST.Tag{
-          element: "div",
-          directives: [],
-          attributes: [],
-          children: [node],
-          meta: meta
-        }
-    end
+    Surface.Compiler.compile(code, meta.line, meta.caller)
   end
 
   defp trim_leading_space(markdown) do


### PR DESCRIPTION
@lnr0626 I'm using `Surface.Compiler.compile/3` to build the AST instead of defining it manually. I believe that since there's no expression to be evaluated at runtime, this approach is valid for this case. For other more complex components where we may pass dynamic expressions via props that might be defined in different lines in the source, we'll need to build the AST manually so we can be able to customize (or keep) the `meta` info.